### PR TITLE
fix: element type invalid

### DIFF
--- a/src/components/Messages.jsx
+++ b/src/components/Messages.jsx
@@ -14,7 +14,7 @@ export default function Messages() {
     );
   if (error)
     return (
-      <Alert status="error" mt="20px">
+      <Alert.Root status="error" mt="20px">
         {error}
         <Button
           ml="5px"
@@ -24,7 +24,7 @@ export default function Messages() {
         >
           try to reconnect
         </Button>
-      </Alert>
+      </Alert.Root>
     );
 
   if (!messages.length)


### PR DESCRIPTION
I think this got introduced after upgrading to v3 of chakra ui. In `messages.jsx`, if there is an error loading messages the `if(error)` condition is true and it results in this error.

![Screenshot 2025-06-17 110539](https://github.com/user-attachments/assets/c8d2579f-72f8-4e6c-85e9-a9f1fdf6eae2)


After wrapping with `Alert.Root`

![image](https://github.com/user-attachments/assets/776a2f12-18a8-45a5-92db-10da47b78370)

