### PR TITLE
Fix: prevent submitting empty or whitespace-only messages

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -70,9 +70,11 @@ export default function Message({ message, isYou }) {
           wordBreak="break-word"
           fontSize="md"
           fontFamily="Montserrat, sans-serif"
+          color="gray.800"
         >
           {truncateText(message.text)}
         </GridItem>
+
         <GridItem
           color="gray"
           fontSize="10px"

--- a/src/components/MessageForm.jsx
+++ b/src/components/MessageForm.jsx
@@ -13,18 +13,18 @@ export default function MessageForm() {
   const handleSubmit = async (e) => {
     e.preventDefault();
 
-    const trimmedMessage = message.trim();
-    if (!trimmedMessage) return;
+    const trimmed = message.trim();
+    if (!trimmed) return;
 
     setIsSending(true);
 
     try {
       const { error } = await supabase.from("messages").insert([
         {
-          text: trimmedMessage,
+          text: trimmed,
           username,
           country,
-          is_authenticated: session ? true : false,
+          is_authenticated: !!session,
         },
       ]);
 
@@ -37,12 +37,12 @@ export default function MessageForm() {
           duration: 9000,
           isClosable: true,
           color: "white",
-          background: "#ef4444", //error
+          background: "#ef4444",
         });
         return;
       }
 
-      setMessage(""); // Clear only after successful send
+      setMessage("");
       console.log("Successfully sent!");
     } catch (error) {
       console.log("Error sending message:", error);
@@ -67,21 +67,19 @@ export default function MessageForm() {
               maxLength="500"
             />
             <IconButton
-              background="teal"
-              colorScheme="teal"
-              aria-label="Send"
-              fontSize="20px"
               icon={<BiSend />}
+              aria-label="Send"
               type="submit"
               disabled={!message.trim()}
               isLoading={isSending}
-            >
-              <BiSend />
-            </IconButton>
+              background="teal"
+              colorScheme="teal"
+              fontSize="20px"
+            />
           </Stack>
         </form>
         <Box fontSize="10px" mt="1">
-          Warning: do not share any sensitive information, it's a public chat
+          Warning: do not share any sensitive information, it’s a public chat
           room 🙂
         </Box>
       </Container>

--- a/src/components/MessageForm.jsx
+++ b/src/components/MessageForm.jsx
@@ -12,15 +12,16 @@ export default function MessageForm() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setIsSending(true);
-    if (!message) return;
 
-    setMessage("");
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) return;
+
+    setIsSending(true);
 
     try {
       const { error } = await supabase.from("messages").insert([
         {
-          text: message,
+          text: trimmedMessage,
           username,
           country,
           is_authenticated: session ? true : false,
@@ -40,9 +41,11 @@ export default function MessageForm() {
         });
         return;
       }
-      console.log("Sucsessfully sent!");
+
+      setMessage(""); // Clear only after successful send
+      console.log("Successfully sent!");
     } catch (error) {
-      console.log("error sending message:", error);
+      console.log("Error sending message:", error);
     } finally {
       setIsSending(false);
     }
@@ -65,13 +68,12 @@ export default function MessageForm() {
             />
             <IconButton
               background="teal"
-              // variant="outline"
               colorScheme="teal"
               aria-label="Send"
               fontSize="20px"
               icon={<BiSend />}
               type="submit"
-              disabled={!message}
+              disabled={!message.trim()}
               isLoading={isSending}
             >
               <BiSend />

--- a/src/components/MessageForm.jsx
+++ b/src/components/MessageForm.jsx
@@ -71,9 +71,8 @@ export default function MessageForm() {
               colorScheme="teal"
               aria-label="Send"
               fontSize="20px"
-              icon={<BiSend />}
               type="submit"
-              disabled={!message}
+              disabled={!message.trim()}
               isLoading={isSending}
             >
               <BiSend />

--- a/src/components/MessageForm.jsx
+++ b/src/components/MessageForm.jsx
@@ -67,15 +67,17 @@ export default function MessageForm() {
               maxLength="500"
             />
             <IconButton
-              icon={<BiSend />}
-              aria-label="Send"
-              type="submit"
-              disabled={!message.trim()}
-              isLoading={isSending}
               background="teal"
               colorScheme="teal"
+              aria-label="Send"
               fontSize="20px"
-            />
+              icon={<BiSend />}
+              type="submit"
+              disabled={!message}
+              isLoading={isSending}
+            >
+              <BiSend />
+            </IconButton>
           </Stack>
         </form>
         <Box fontSize="10px" mt="1">


### PR DESCRIPTION
## Problem
Messages were being cleared before being sent to Supabase, resulting in empty or whitespace-only messages being saved.

## Solution
- Now trims and validates messages before submitting.
- Prevents submitting empty or space-only messages.
- Clears the input only after a successful insert.

This is a frontend fix that resolves the issue at the source. Optional backend validation could be added later for additional safety.
