### PR TITLE
Change user message text color to black for better visibility

### DIFF
--- a/src/components/Message.jsx
+++ b/src/components/Message.jsx
@@ -70,6 +70,7 @@ export default function Message({ message, isYou }) {
           wordBreak="break-word"
           fontSize="md"
           fontFamily="Montserrat, sans-serif"
+          color="#000"
         >
           {truncateText(message.text)}
         </GridItem>


### PR DESCRIPTION
The previous white text was difficult to read (disappearing), and I've updated it to black for better contrast.